### PR TITLE
fix: harden API responses from PostHog exceptions

### DIFF
--- a/apps/tabt-rest/src/api/member/controllers/member.controller.spec.ts
+++ b/apps/tabt-rest/src/api/member/controllers/member.controller.spec.ts
@@ -36,7 +36,7 @@ describe('MemberController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should call members service with correct param', async () => {
+  it('should return an empty list when the member search has no result', async () => {
     const input = {
       club: 'L360',
       uniqueIndex: 142453,
@@ -49,13 +49,10 @@ describe('MemberController', () => {
     };
     const spy = jest.spyOn(service, 'getMembersV1').mockResolvedValue([]);
 
-    try {
-      await controller.findAll(input as unknown as GetMemberV1);
-    } catch (error) {
-      expect(error).toBeDefined();
-      expect(error).toBeInstanceOf(NotFoundException);
-      expect(spy).toHaveBeenCalledWith(input);
-    }
+    await expect(
+      controller.findAll(input as unknown as GetMemberV1),
+    ).resolves.toEqual([]);
+    expect(spy).toHaveBeenCalledWith(input);
   });
 
   it('should call members service with correct param - 1 player', async () => {

--- a/apps/tabt-rest/src/api/member/controllers/member.controller.ts
+++ b/apps/tabt-rest/src/api/member/controllers/member.controller.ts
@@ -23,7 +23,6 @@ import {
   MemberEntryDTOV1,
   PlayerCategoryEntriesDTOV1,
   WeeklyNumericPointsInputV1,
-  WeeklyNumericPointsV1,
 } from '../dto/member.dto';
 import { MemberCategoryService } from '../../../services/members/member-category.service';
 import {
@@ -54,9 +53,6 @@ export class MemberController {
   @TabtHeadersDecorator()
   async findAll(@Query() input: GetMembersV1): Promise<MemberEntryDTOV1[]> {
     const members = await this.memberService.getMembersV1(input);
-    if (members.length === 0) {
-      throw new NotFoundException('No members found');
-    }
     return members.map(MemberEntryDTOV1.fromTabT);
   }
 
@@ -109,8 +105,8 @@ export class MemberController {
 
   @Get(':uniqueIndex/numeric-rankings')
   @ApiOkResponse({
-    type: WeeklyNumericPointsV1,
-    description: 'The list of ELO points for a player in a season',
+    type: WeeklyRankingV1Response,
+    description: 'The numeric ranking history for a player in a season',
   })
   @ApiOperation({
     operationId: 'findMemberNumericRankingsHistoryV1',

--- a/apps/tabt-rest/src/api/tournament/controllers/tournament.controller.spec.ts
+++ b/apps/tabt-rest/src/api/tournament/controllers/tournament.controller.spec.ts
@@ -78,6 +78,14 @@ describe('TournamentController', () => {
         new NotFoundException(),
       );
     });
+
+    it('should return an empty list when TabT omits series entries', async () => {
+      jest
+        .spyOn(tournamentService, 'getTournaments')
+        .mockResolvedValue([{}] as never);
+
+      await expect(controller.getSeriesV1(123)).resolves.toEqual([]);
+    });
   });
 
   describe('Tournament registration', () => {

--- a/apps/tabt-rest/src/api/tournament/controllers/tournament.controller.ts
+++ b/apps/tabt-rest/src/api/tournament/controllers/tournament.controller.ts
@@ -103,7 +103,9 @@ export class TournamentController {
       WithRegistrations: true,
     });
     if (result.length) {
-      return result[0].SerieEntries.map(TournamentSerieEntryDTOV1.fromTabT);
+      return (result[0].SerieEntries ?? []).map(
+        TournamentSerieEntryDTOV1.fromTabT,
+      );
     }
     throw new NotFoundException();
   }

--- a/apps/tabt-rest/src/services/members/head2head.service.spec.ts
+++ b/apps/tabt-rest/src/services/members/head2head.service.spec.ts
@@ -114,6 +114,27 @@ describe('Head2headService', () => {
       );
     });
 
+    it('should parse player inputs regardless of attribute order and quotes', async () => {
+      mockHttpService.post.mockReturnValue(
+        of({
+          data: `
+            <input value='123/Player One' class='player' name='player_1' id='player_1'>
+            <input name='player_2' value='456/Player Two' id='player_2'>
+            <a href='?season=2023&sel=1&detail=123&week_name=1&div_id=1'>Match 01/23</a>
+          `,
+        }),
+      );
+
+      const result = await service.getHead2HeadResults(123, 456);
+
+      expect(result.playersInfo).toEqual({
+        playerUniqueIndex: 123,
+        opponentPlayerUniqueIndex: 456,
+        playerName: 'Player One',
+        opponentPlayerName: 'Player Two',
+      });
+    });
+
     it('should use the same stable cache key for both player orders', async () => {
       await service.getHead2HeadResults(123, 456);
       await service.getHead2HeadResults(456, 123);

--- a/apps/tabt-rest/src/services/members/head2head.service.ts
+++ b/apps/tabt-rest/src/services/members/head2head.service.ts
@@ -9,6 +9,7 @@ import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
+import { DOMParser } from '@xmldom/xmldom';
 
 import { MatchService } from '../matches/match.service';
 import { TeamMatchesEntry } from '../../entity/tabt-soap/TabTAPI_Port';
@@ -446,57 +447,51 @@ export class Head2headService {
   private extractPlayerNames(htmlPage: string): PlayersInfo {
     this.logger.debug('Extracting player names from HTML');
 
-    // Match pattern: <INPUT ... id="player_1" name="player_1" value="130573/BAUDOUIN LOOS">
-    const regex =
-      /id="player_([12])"[^>]*name="player_\1"[^>]*value="([0-9]+)\/([^"]+)"/gm;
-    this.logger.debug(`Using regex pattern: ${regex.toString()}`);
+    const normalizedHtml = /<html(?:\s|>)/i.test(htmlPage)
+      ? htmlPage
+      : `<html><body>${htmlPage}</body></html>`;
+    const document = new DOMParser({
+      onError: () => undefined,
+    }).parseFromString(normalizedHtml, 'text/html');
+    const readPlayer = (index: 1 | 2): [string, string] | null => {
+      const value = document
+        .getElementById(`player_${index}`)
+        ?.getAttribute('value')
+        ?.trim();
+      if (!value) return null;
 
-    const players: Array<[string, string]> = [];
-    let matchCount = 0;
+      const separator = value.indexOf('/');
+      if (separator <= 0) return null;
 
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(htmlPage)) !== null) {
-      matchCount++;
-      const playerIndex = Number(match[1]);
-      const uniqueIndex = match[2];
-      const name = match[3].trim();
-      this.logger.debug(
-        `Found player ${playerIndex}: uniqueIndex=${uniqueIndex}, name="${name}"`,
-      );
-      players[playerIndex - 1] = [uniqueIndex, name];
-    }
+      const uniqueIndex = value.slice(0, separator).trim();
+      const name = value.slice(separator + 1).trim();
+      if (!/^\d+$/.test(uniqueIndex) || !name) return null;
+      return [uniqueIndex, name];
+    };
 
-    this.logger.debug(`Extracted ${matchCount} player matches`);
-
-    if (players.length !== 2 || !players[0] || !players[1]) {
+    const player = readPlayer(1);
+    const opponent = readPlayer(2);
+    if (!player || !opponent) {
+      const inputs = document.getElementsByTagName('input');
+      let playerInputCount = 0;
+      for (let index = 0; index < inputs.length; index++) {
+        if (inputs[index].getAttribute('id')?.startsWith('player_')) {
+          playerInputCount++;
+        }
+      }
       this.logger.error(
-        `Failed to extract player information. Found ${players.length} players: ${JSON.stringify(players)}`,
+        `Failed to extract player information. playerInputs=${playerInputCount}, htmlLength=${htmlPage.length}`,
       );
-      // Try alternative patterns
-      const altPattern1 = htmlPage.match(/id="player_1"[^>]*value="([^"]+)"/i);
-      const altPattern2 = htmlPage.match(/id="player_2"[^>]*value="([^"]+)"/i);
-      if (altPattern1) {
-        this.logger.debug(
-          `Alternative pattern found player_1: ${altPattern1[1]}`,
-        );
-      }
-      if (altPattern2) {
-        this.logger.debug(
-          `Alternative pattern found player_2: ${altPattern2[1]}`,
-        );
-      }
       throw new Error('Failed to extract player information');
     }
 
     const result = {
-      playerName: players[0][1],
-      playerUniqueIndex: Number(players[0][0]),
-      opponentPlayerName: players[1][1],
-      opponentPlayerUniqueIndex: Number(players[1][0]),
+      playerName: player[1],
+      playerUniqueIndex: Number(player[0]),
+      opponentPlayerName: opponent[1],
+      opponentPlayerUniqueIndex: Number(opponent[0]),
     };
-    this.logger.debug(
-      `Successfully extracted players: ${result.playerName} (${result.playerUniqueIndex}) vs ${result.opponentPlayerName} (${result.opponentPlayerUniqueIndex})`,
-    );
+    this.logger.debug('Successfully extracted both players');
 
     return result;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,15 +7,17 @@ settings:
 overrides:
   '@hono/node-server@1': 1.19.13
   body-parser: 2.3.0
-  brace-expansion@2: 2.1.2
-  brace-expansion@5: 5.0.7
-  fast-uri: 3.1.4
+  brace-expansion@2: 2.1.4
+  brace-expansion@5: 5.0.9
+  fast-uri: 3.1.5
+  find-my-way: 9.7.0
   hono: 4.12.27
-  js-yaml: 4.3.0
+  ip-address: 10.3.1
+  js-yaml: 4.3.1
   multer: 2.2.0
   protobufjs: 7.6.5
   qs: 6.15.2
-  undici: 7.28.0
+  undici: 7.29.0
   uuid@<11.1.1: 11.1.1
 
 importers:
@@ -2358,12 +2360,12 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.6:
     resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
@@ -3036,8 +3038,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -3078,8 +3080,8 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-my-way@9.6.0:
-    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@4.1.0:
@@ -3425,8 +3427,8 @@ packages:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3663,8 +3665,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5019,8 +5021,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   universalify@2.0.1:
@@ -5929,7 +5931,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -6372,7 +6374,7 @@ snapshots:
       '@nestjs/common': 11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
       '@nestjs/core': 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/microservices@11.1.28)(@nestjs/platform-express@11.1.28)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
@@ -6474,7 +6476,7 @@ snapshots:
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.11
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       foreground-child: 3.3.1
       get-port-please: 3.2.0
       pathe: 2.0.3
@@ -7307,14 +7309,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7502,11 +7504,11 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7737,7 +7739,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -8156,7 +8158,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.3.0:
     dependencies:
@@ -8215,7 +8217,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
@@ -8673,7 +8675,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -9077,7 +9079,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -9098,7 +9100,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9316,7 +9318,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -9324,7 +9326,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -10036,7 +10038,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.3.1
       smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
@@ -10420,7 +10422,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   universalify@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,15 +17,17 @@ peerDependencyRules:
 overrides:
   '@hono/node-server@1': 1.19.13
   body-parser: 2.3.0
-  'brace-expansion@2': 2.1.2
-  'brace-expansion@5': 5.0.7
-  fast-uri: 3.1.4
+  'brace-expansion@2': 2.1.4
+  'brace-expansion@5': 5.0.9
+  fast-uri: 3.1.5
+  find-my-way: 9.7.0
   hono: 4.12.27
-  js-yaml: 4.3.0
+  ip-address: 10.3.1
+  js-yaml: 4.3.1
   multer: 2.2.0
   protobufjs: 7.6.5
   qs: 6.15.2
-  undici: 7.28.0
+  undici: 7.29.0
   'uuid@<11.1.1': 11.1.1
 
 # Deps permitted to run install scripts.


### PR DESCRIPTION
## What changed

- Return an empty member list instead of turning a valid empty search into a 404.
- Handle tournament payloads where `SerieEntries` is omitted.
- Parse AFTT head-to-head player inputs with a DOM parser so attribute order and quote style no longer break extraction.
- Correct the numeric-ranking OpenAPI response to `WeeklyRankingV1Response`.
- Add regression coverage for the production payload shapes.

## Why

PostHog exceptions from the previous 12 hours showed expected empty states being reported as errors, an undefined tournament series being mapped, and brittle AFTT HTML parsing. The published numeric-ranking contract also disagreed with the runtime response.

## Impact

Expected empty data now degrades cleanly, upstream HTML variations are tolerated, and generated clients can use the actual numeric-ranking response model.

## Validation

- 25 targeted Jest tests
- `pnpm run typecheck:all` (TypeScript 6 and 7)
- ESLint on all changed TypeScript files
- `pnpm run build:tabt-rest`
