### PR TITLE
fix: slim challenge worker runtime image

### DIFF
--- a/apps/challenge-worker/Dockerfile
+++ b/apps/challenge-worker/Dockerfile
@@ -13,14 +13,22 @@ COPY libs ./libs
 COPY prisma ./prisma
 RUN pnpm prisma:generate && pnpm build:challenge-worker
 
+FROM node:${NODE_VERSION} AS prod-deps
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+WORKDIR /app
+RUN npm install -g pnpm@11.15.1
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --prod --frozen-lockfile
+
 FROM node:${NODE_VERSION} AS runner
 WORKDIR /app
 ENV NODE_ENV=production \
     DB_POOL_MAX=1
-RUN npm install -g pnpm@11.15.1 \
-    && apk add --no-cache dumb-init openssl
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN pnpm install --prod --frozen-lockfile
+RUN apk add --no-cache dumb-init openssl
+COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules
+COPY --chown=node:node package.json ./
 COPY --from=builder /app/dist/apps/challenge-worker ./dist/apps/challenge-worker
 COPY --from=builder /app/libs/common/src/generated/prisma ./libs/common/src/generated/prisma
 USER node


### PR DESCRIPTION
## Summary
- install production dependencies in an isolated Docker stage
- copy only runtime node_modules into the final worker image
- avoid shipping the pnpm store in the runtime layer

## Verification
- previous multiarchitecture build compiled successfully but the registry rejected the oversized final layer with invalid content range
- this follows the proven runtime layout used by the API, notifications and importer images
