### PR TITLE
ci(challenges): allow disabled schedules before timezone setup

### DIFF
--- a/.github/workflows/deploy-challenges-production.yml
+++ b/.github/workflows/deploy-challenges-production.yml
@@ -101,8 +101,7 @@ jobs:
           server="$(coolify GET "/servers/${SERVER_UUID}")"
           timezone="$(jq -r '.settings.server_timezone // empty' <<<"${server}")"
           if [[ "${timezone}" != 'Europe/Brussels' ]]; then
-            echo "The BePing Coolify server timezone must be Europe/Brussels." >&2
-            exit 1
+            echo "::warning::The BePing Coolify server timezone is ${timezone:-unset}. Challenge schedules are being provisioned disabled and must not be enabled before the server timezone is Europe/Brussels."
           fi
 
           api_application="$(coolify GET "/applications/${API_UUID}")"


### PR DESCRIPTION
## Summary\n- allow provisioning the challenge worker and website while the BePing Coolify server remains on UTC\n- keep all three schedules disabled\n- emit a deployment warning that activation is forbidden until the server timezone is Europe/Brussels\n\n## Safety\nNo scheduled task is enabled by this change. Production activation remains blocked operationally until the server timezone is corrected.