### PR TITLE
fix(challenges): stabilize production worker deployment

### DIFF
--- a/.github/workflows/deploy-challenges-production.yml
+++ b/.github/workflows/deploy-challenges-production.yml
@@ -85,6 +85,7 @@ jobs:
             local method="$1"
             local path="$2"
             local payload="${3:-}"
+            local response
             local args=(
               --fail-with-body --silent --show-error
               --connect-timeout 10 --max-time 30
@@ -95,7 +96,12 @@ jobs:
             if [[ -n "${payload}" ]]; then
               args+=(--data "${payload}")
             fi
-            curl "${args[@]}" "${api_base}${path}"
+            if ! response="$(curl "${args[@]}" "${api_base}${path}")"; then
+              echo "Coolify ${method} ${path} failed." >&2
+              jq -c '{message, errors}' <<<"${response}" >&2 2>/dev/null || true
+              return 1
+            fi
+            printf '%s' "${response}"
           }
 
           server="$(coolify GET "/servers/${SERVER_UUID}")"

--- a/.github/workflows/deploy-challenges-production.yml
+++ b/.github/workflows/deploy-challenges-production.yml
@@ -209,8 +209,6 @@ jobs:
 
           worker_configuration="$({
             jq -n '{
-              domains: null,
-              ports_exposes: null,
               is_auto_deploy_enabled: false,
               limits_cpus: "0.5",
               limits_memory: "768M",

--- a/apps/challenge-worker/src/main.ts
+++ b/apps/challenge-worker/src/main.ts
@@ -31,8 +31,15 @@ async function bootstrap(): Promise<void> {
     if (job === 'idle') {
       console.log('CHALLENGE_WORKER_READY');
       await new Promise<void>((resolve) => {
-        process.once('SIGINT', resolve);
-        process.once('SIGTERM', resolve);
+        const keepAlive = setInterval(() => undefined, 60_000);
+        const shutdown = (): void => {
+          clearInterval(keepAlive);
+          process.off('SIGINT', shutdown);
+          process.off('SIGTERM', shutdown);
+          resolve();
+        };
+        process.once('SIGINT', shutdown);
+        process.once('SIGTERM', shutdown);
       });
       return;
     }


### PR DESCRIPTION
## Summary\n- keep the idle challenge worker alive with an active timer until SIGINT/SIGTERM\n- report sanitized Coolify API validation errors\n- avoid sending invalid null worker port fields to the production Coolify version\n\n## Verification\n- Prisma client generation passed\n- challenge-worker Nest build passed\n- production schedules remain disabled