### PR TITLE
fix: parse doctype-prefixed head-to-head fragments

### DIFF
--- a/apps/tabt-rest/src/services/members/head2head.service.spec.ts
+++ b/apps/tabt-rest/src/services/members/head2head.service.spec.ts
@@ -135,6 +135,27 @@ describe('Head2headService', () => {
       });
     });
 
+    it('should parse a doctype-prefixed HTML fragment', async () => {
+      mockHttpService.post.mockReturnValue(
+        of({
+          data: `
+            <!DOCTYPE html>
+            <input id="player_1" value="123/Player One">
+            <input id="player_2" value="456/Player Two">
+          `,
+        }),
+      );
+
+      const result = await service.getHead2HeadResults(123, 456);
+
+      expect(result.playersInfo).toEqual({
+        playerUniqueIndex: 123,
+        opponentPlayerUniqueIndex: 456,
+        playerName: 'Player One',
+        opponentPlayerName: 'Player Two',
+      });
+    });
+
     it('should use the same stable cache key for both player orders', async () => {
       await service.getHead2HeadResults(123, 456);
       await service.getHead2HeadResults(456, 123);

--- a/apps/tabt-rest/src/services/members/head2head.service.ts
+++ b/apps/tabt-rest/src/services/members/head2head.service.ts
@@ -447,9 +447,13 @@ export class Head2headService {
   private extractPlayerNames(htmlPage: string): PlayersInfo {
     this.logger.debug('Extracting player names from HTML');
 
-    const normalizedHtml = /<html(?:\s|>)/i.test(htmlPage)
-      ? htmlPage
-      : `<html><body>${htmlPage}</body></html>`;
+    // AFTT sometimes returns a doctype followed by an HTML fragment without an
+    // <html> root. Wrapping that verbatim puts the doctype inside <body>, which
+    // @xmldom rejects before we can inspect the player inputs.
+    const htmlWithoutDoctype = htmlPage.replace(/<!doctype[^>]*>/gi, '');
+    const normalizedHtml = /<html(?:\s|>)/i.test(htmlWithoutDoctype)
+      ? htmlWithoutDoctype
+      : `<html><body>${htmlWithoutDoctype}</body></html>`;
     const document = new DOMParser({
       onError: () => undefined,
     }).parseFromString(normalizedHtml, 'text/html');


### PR DESCRIPTION
## Impact

A new backend issue produced 17 exceptions across 3 users in 24 hours and prevented Head2Head results from loading.

## Root cause

AFTT can return a doctype-prefixed fragment without an `<html>` root. Wrapping it verbatim places the doctype inside `<body>`, which `@xmldom/xmldom` rejects before player inputs are parsed.

## Fix

Remove the doctype before normalizing fragments into an HTML root. Complete documents and player extraction behavior remain unchanged.

## Tests

- `pnpm exec jest --runInBand --runTestsByPath apps/tabt-rest/src/services/members/head2head.service.spec.ts --coverage=false` (14 passed)
- ESLint on the changed service and spec
- `pnpm run build:tabt-rest`

## PostHog

Production issue: https://eu.posthog.com/project/216441/error_tracking/019fef8a-ad4b-7be2-a79f-2f1df543e421
