### PR TITLE
fix: make device unregistration idempotent

### DIFF
--- a/apps/app-notifications/src/notifications/fcm.service.spec.ts
+++ b/apps/app-notifications/src/notifications/fcm.service.spec.ts
@@ -189,6 +189,27 @@ describe('FcmService dispatch', () => {
   });
 });
 
+describe('FcmService device unregistration', () => {
+  it('succeeds when the device subscription no longer exists', async () => {
+    const updateMany = jest.fn().mockResolvedValue({ count: 0 });
+    const prisma = {
+      deviceSubscription: { updateMany },
+    } as unknown as PrismaService;
+    const service = new FcmService(prisma, {
+      capture: jest.fn(),
+    } as unknown as PostHogService);
+
+    await expect(
+      service.unregisterDevice('missing-token'),
+    ).resolves.toBeUndefined();
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { deviceToken: 'missing-token' },
+      data: { active: false },
+    });
+  });
+});
+
 describe('FcmService topic lookup', () => {
   it('deduplicates devices subscribed through several matching topics', async () => {
     const findMany = jest.fn().mockResolvedValue([

--- a/apps/app-notifications/src/notifications/fcm.service.ts
+++ b/apps/app-notifications/src/notifications/fcm.service.ts
@@ -137,7 +137,9 @@ export class FcmService implements OnModuleInit {
 
   async unregisterDevice(deviceToken: string): Promise<void> {
     try {
-      await this.prisma.deviceSubscription.update({
+      // Unregistration is idempotent: clients can retry it after their local
+      // token has already been removed or replaced.
+      await this.prisma.deviceSubscription.updateMany({
         where: { deviceToken },
         data: { active: false },
       });


### PR DESCRIPTION
## Impact

Production recorded 5 backend exceptions across 3 users, with correlated 500 responses in the Flutter notification onboarding flow.

## Root cause

Device unregistration used Prisma `update`, which throws when a retried request targets a token that has already been removed or replaced.

## Fix

Use `updateMany` so a zero-row update is a successful idempotent unregistration while real database failures still propagate.

## Tests

- `pnpm exec jest --runInBand --runTestsByPath apps/app-notifications/src/notifications/fcm.service.spec.ts --coverage=false` (6 passed)
- ESLint on the changed service and spec
- `pnpm run build:app-notifications`

## PostHog

Production issue: https://eu.posthog.com/project/216441/error_tracking/019fef9a-702a-7fa2-bf0c-c381b0ae0776
