### PR TITLE
ci(challenges): version and auto-deploy worker

### DIFF
--- a/.github/workflows/deploy-challenge-worker-production.yml
+++ b/.github/workflows/deploy-challenge-worker-production.yml
@@ -1,0 +1,164 @@
+name: Deploy challenge worker production
+
+on:
+  workflow_call:
+    inputs:
+      image_sha:
+        description: Immutable backend SHA containing the released challenge worker
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      image_sha:
+        description: Immutable backend SHA containing the released challenge worker
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: beping-challenges-production
+  cancel-in-progress: false
+
+env:
+  REGISTRY_HOST: ${{ vars.HETZNER_REGISTRY_HOST }}
+  COOLIFY_URL: ${{ vars.COOLIFY_URL }}
+  BEPING_DOCKER_HOST: ${{ vars.BEPING_DOCKER_HOST }}
+  WORKER_UUID: ${{ vars.COOLIFY_BEPING_CHALLENGE_WORKER_UUID }}
+  IMAGE_SHA: ${{ inputs.image_sha }}
+  BEPING_BACKUP_DIRECTORY: /data/coolify/backups/databases/escape-key-team-0/beping-postgresql-18-${{ vars.COOLIFY_BEPING_POSTGRES18_UUID }}
+  BEPING_BACKUP_MAX_AGE_MINUTES: 1560
+
+jobs:
+  deploy:
+    name: Promote released challenge worker
+    runs-on: [self-hosted, linux, x64, escape-key-ci]
+    environment: Production
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout deployment tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate deployment configuration
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          REGISTRY_USERNAME: ${{ secrets.HETZNER_REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.HETZNER_REGISTRY_PASSWORD }}
+        run: |
+          [[ "${IMAGE_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          test -n "${REGISTRY_HOST}"
+          test -n "${REGISTRY_USERNAME}"
+          test -n "${REGISTRY_PASSWORD}"
+          test -n "${COOLIFY_URL}"
+          test -n "${COOLIFY_TOKEN}"
+          test -n "${BEPING_DOCKER_HOST}"
+          test -n "${WORKER_UUID}"
+
+      - name: Log in to Escape Key registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.HETZNER_REGISTRY_USERNAME }}
+          password: ${{ secrets.HETZNER_REGISTRY_PASSWORD }}
+
+      - name: Verify immutable worker image
+        run: |
+          docker manifest inspect \
+            "${REGISTRY_HOST}/escape-key/beping-challenge-worker:${IMAGE_SHA}" \
+            >/dev/null
+
+      - name: Verify recent PostgreSQL backup and API readiness
+        run: |
+          docker_ssh_target="${BEPING_DOCKER_HOST#ssh://}"
+          [[ "${BEPING_DOCKER_HOST}" == "ssh://${docker_ssh_target}" ]]
+          [[ "${docker_ssh_target}" =~ ^root@[a-zA-Z0-9.-]+$ ]]
+
+          ssh \
+            -o BatchMode=yes \
+            -o ConnectTimeout=10 \
+            "${docker_ssh_target}" \
+            "find '${BEPING_BACKUP_DIRECTORY}' -maxdepth 1 -type f -name '*.dmp' -size +1048576c -mmin -${BEPING_BACKUP_MAX_AGE_MINUTES} -print -quit" \
+            | grep -q .
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --connect-timeout 10 \
+            --max-time 30 \
+            https://api-v2.beping.be/v1/health/ready \
+            >/dev/null
+
+      - name: Deploy released challenge worker
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+        run: |
+          update_provenance() {
+            local image_sha="$1"
+            jq -n \
+              --arg image_sha "${image_sha}" \
+              '{data: [
+                {key: "CHALLENGE_WORKER_IMAGE_SHA", value: $image_sha, is_literal: true, is_runtime: true, is_buildtime: false}
+              ]}' | curl \
+                --fail-with-body \
+                --silent \
+                --show-error \
+                --output /dev/null \
+                -X PATCH \
+                -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+                -H 'Content-Type: application/json' \
+                --data-binary @- \
+                "${COOLIFY_URL%/}/api/v1/applications/${WORKER_UUID}/envs/bulk"
+          }
+
+          current="$(curl \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+            "${COOLIFY_URL%/}/api/v1/applications/${WORKER_UUID}")"
+          previous_image="$(jq -er '.docker_registry_image_name' <<<"${current}")"
+          previous_tag="$(jq -er '.docker_registry_image_tag' <<<"${current}")"
+
+          update_provenance "${IMAGE_SHA}"
+          if ! bash scripts/coolify-deploy-image.sh \
+              "${WORKER_UUID}" \
+              "${REGISTRY_HOST}/escape-key/beping-challenge-worker" \
+              "${IMAGE_SHA}"; then
+            update_provenance "${previous_tag}" || true
+            exit 1
+          fi
+
+          expected_image="${REGISTRY_HOST}/escape-key/beping-challenge-worker:${IMAGE_SHA}"
+          for _ in $(seq 1 30); do
+            if docker --host "${BEPING_DOCKER_HOST}" ps \
+              --filter "name=${WORKER_UUID}" \
+              --filter "ancestor=${expected_image}" \
+              --format '{{.ID}}' | grep -q .; then
+              echo "Released challenge worker ${IMAGE_SHA} is running."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "The released challenge worker did not remain running; restoring ${previous_tag}." >&2
+          update_provenance "${previous_tag}" || true
+          bash scripts/coolify-deploy-image.sh \
+            "${WORKER_UUID}" \
+            "${previous_image}" \
+            "${previous_tag}" || true
+          exit 1
+
+      - name: Verify schedules remain disabled until activation
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+        run: |
+          tasks="$(curl \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+            "${COOLIFY_URL%/}/api/v1/applications/${WORKER_UUID}/scheduled-tasks")"
+          [[ "$(jq '[.[] | select(.enabled == false)] | length' <<<"${tasks}")" -eq 3 ]]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,8 @@ jobs:
       data-aftt-importer--tag_name: ${{ steps.release.outputs['apps/data-aftt-importer--tag_name'] }}
       app-notifications--release_created: ${{ steps.release.outputs['apps/app-notifications--release_created'] }}
       app-notifications--tag_name: ${{ steps.release.outputs['apps/app-notifications--tag_name'] }}
+      challenge-worker--release_created: ${{ steps.release.outputs['apps/challenge-worker--release_created'] }}
+      challenge-worker--tag_name: ${{ steps.release.outputs['apps/challenge-worker--tag_name'] }}
     steps:
       - uses: actions/checkout@v7
 
@@ -62,6 +64,10 @@ jobs:
             release_created: ${{ needs.release-please.outputs.app-notifications--release_created }}
             tag_name: ${{ needs.release-please.outputs.app-notifications--tag_name }}
             image_name: ${{ vars.HETZNER_REGISTRY_HOST }}/escape-key/beping-notifications
+          - app: challenge-worker
+            release_created: ${{ needs.release-please.outputs.challenge-worker--release_created }}
+            tag_name: ${{ needs.release-please.outputs.challenge-worker--tag_name }}
+            image_name: ${{ vars.HETZNER_REGISTRY_HOST }}/escape-key/beping-challenge-worker
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -166,6 +172,26 @@ jobs:
         needs.build-and-push-migrate.result == 'success'
       }}
     uses: ./.github/workflows/deploy-production.yml
+    with:
+      image_sha: ${{ github.sha }}
+    secrets: inherit
+
+  deploy-challenge-worker-production:
+    needs:
+      - release-please
+      - build-and-push
+      - build-and-push-migrate
+      - deploy-production
+    if: >-
+      ${{
+        always() &&
+        github.ref == 'refs/heads/main' &&
+        needs.release-please.outputs.challenge-worker--release_created == 'true' &&
+        needs.build-and-push.result == 'success' &&
+        needs.build-and-push-migrate.result == 'success' &&
+        needs.deploy-production.result == 'success'
+      }}
+    uses: ./.github/workflows/deploy-challenge-worker-production.yml
     with:
       image_sha: ${{ github.sha }}
     secrets: inherit

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "apps/tabt-rest": "2.7.0",
   "apps/data-aftt-importer": "2.3.0",
-  "apps/app-notifications": "2.5.0"
+  "apps/app-notifications": "2.5.0",
+  "apps/challenge-worker": "0.0.0"
 }

--- a/apps/challenge-worker/package.json
+++ b/apps/challenge-worker/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "challenge-worker",
+  "version": "0.0.0",
+  "description": "Community challenge calculation and publication worker",
+  "private": true
+}

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -63,6 +63,12 @@ values only in Coolify; PostgreSQL contains their environment-variable names.
 See `apps/challenge-worker/README.md` and `docs/challenge-cutover.md` before
 activation.
 
+`challenge-worker` is a Release Please component. Merging its release PR builds
+the semantic-version and immutable SHA tags, runs the shared migration and
+backend promotion first, then automatically promotes only the worker through
+the protected Production environment. The challenge website remains on its
+independent, explicitly selected frontend revision.
+
 The importer deliberately trades duration for API availability:
 
 - set its CPU shares below the API and cap it at `0.35` CPU;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,11 @@
     "apps/app-notifications": {
       "package-name": "app-notifications",
       "component": "app-notifications"
+    },
+    "apps/challenge-worker": {
+      "package-name": "challenge-worker",
+      "component": "challenge-worker",
+      "initial-version": "1.0.0"
     }
   },
   "plugins": [


### PR DESCRIPTION
## Résumé

- ajoute `challenge-worker` comme composant Release Please, avec une première release `1.0.0`
- publie ses tags Docker SHA et semver avec les autres applications
- déploie automatiquement le worker après la réussite des migrations et de la promotion backend
- conserve le frontend challenges sur sa révision indépendante
- vérifie le backup PostgreSQL, la readiness API, la provenance de l’image et l’état du processus
- restaure l’image et la provenance précédentes si la promotion échoue
- garde les trois tâches planifiées désactivées jusqu’à leur activation fonctionnelle

## Configuration

La variable de dépôt `COOLIFY_BEPING_CHALLENGE_WORKER_UUID` a été configurée avec l’UUID Coolify actuellement actif.

## Validation

- schémas JSON et Release Please
- Prettier
- `actionlint` 1.7.12
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec jest --runInBand` — 73 suites, 359 tests
- `pnpm run build:challenge-worker`

## Déroulement après fusion

Release Please ouvrira la release initiale du worker. La fusion de cette PR de release construira les images, appliquera les migrations et déploiera le backend, puis promouvra automatiquement le worker via le runner privé et l’environnement GitHub `Production`.