### PR TITLE
fix: parse malformed AFTT head-to-head HTML

### DIFF
--- a/apps/tabt-rest/src/services/members/head2head.service.spec.ts
+++ b/apps/tabt-rest/src/services/members/head2head.service.spec.ts
@@ -156,6 +156,27 @@ describe('Head2headService', () => {
       });
     });
 
+    it('should parse player inputs inside malformed surrounding HTML', async () => {
+      mockHttpService.post.mockReturnValue(
+        of({
+          data: `
+            <div><p>Malformed AFTT markup</div>
+            <input id="player_1" value="123/Player One">
+            <input value="456/Player Two" id="player_2">
+          `,
+        }),
+      );
+
+      const result = await service.getHead2HeadResults(123, 456);
+
+      expect(result.playersInfo).toEqual({
+        playerUniqueIndex: 123,
+        opponentPlayerUniqueIndex: 456,
+        playerName: 'Player One',
+        opponentPlayerName: 'Player Two',
+      });
+    });
+
     it('should use the same stable cache key for both player orders', async () => {
       await service.getHead2HeadResults(123, 456);
       await service.getHead2HeadResults(456, 123);

--- a/apps/tabt-rest/src/services/members/head2head.service.ts
+++ b/apps/tabt-rest/src/services/members/head2head.service.ts
@@ -454,14 +454,23 @@ export class Head2headService {
     const normalizedHtml = /<html(?:\s|>)/i.test(htmlWithoutDoctype)
       ? htmlWithoutDoctype
       : `<html><body>${htmlWithoutDoctype}</body></html>`;
-    const document = new DOMParser({
-      onError: () => undefined,
-    }).parseFromString(normalizedHtml, 'text/html');
+    const parser = new DOMParser({ onError: () => undefined });
+    const inputTags = normalizedHtml.match(/<input\b[^>]*>/gi) ?? [];
+    const playerInputs = new Map<string, string>();
+    for (const inputTag of inputTags) {
+      // Parse each input independently. The surrounding AFTT fragment can
+      // contain mismatched tags, but the two player inputs are self-contained.
+      const inputDocument = parser.parseFromString(
+        `<html><body>${inputTag}</body></html>`,
+        'text/html',
+      );
+      const input = inputDocument.getElementsByTagName('input')[0];
+      const id = input?.getAttribute('id');
+      const value = input?.getAttribute('value')?.trim();
+      if (id && value) playerInputs.set(id, value);
+    }
     const readPlayer = (index: 1 | 2): [string, string] | null => {
-      const value = document
-        .getElementById(`player_${index}`)
-        ?.getAttribute('value')
-        ?.trim();
+      const value = playerInputs.get(`player_${index}`);
       if (!value) return null;
 
       const separator = value.indexOf('/');
@@ -476,13 +485,9 @@ export class Head2headService {
     const player = readPlayer(1);
     const opponent = readPlayer(2);
     if (!player || !opponent) {
-      const inputs = document.getElementsByTagName('input');
-      let playerInputCount = 0;
-      for (let index = 0; index < inputs.length; index++) {
-        if (inputs[index].getAttribute('id')?.startsWith('player_')) {
-          playerInputCount++;
-        }
-      }
+      const playerInputCount = [...playerInputs.keys()].filter((id) =>
+        id.startsWith('player_'),
+      ).length;
       this.logger.error(
         `Failed to extract player information. playerInputs=${playerInputCount}, htmlLength=${htmlPage.length}`,
       );


### PR DESCRIPTION
## Impact

PostHog recorded a new production issue with 19 occurrences across 3 users and 3 sessions in the last 24 hours.

## Root cause

AFTT returned a fragment containing mismatched surrounding `p` and `div` tags. `@xmldom/xmldom` treats that mismatch as fatal when parsing the entire fragment, even though the two player input tags remain valid.

## Fix

Extract and parse each player `input` tag independently. This preserves DOM attribute decoding and attribute-order tolerance without depending on unrelated third-party markup being well formed.

## Tests

- `pnpm exec jest apps/tabt-rest/src/services/members/head2head.service.spec.ts --runInBand --coverage=false` (15 passed)
- targeted ESLint
- `pnpm run build:tabt-rest`

## PostHog

[Issue 019ff57a-c0e0-7d40-be0b-f298035e808b](https://eu.posthog.com/project/216441/error_tracking/019ff57a-c0e0-7d40-be0b-f298035e808b)
