### PR TITLE
fix: make device locale updates idempotent

### DIFF
--- a/apps/app-notifications/src/notifications/fcm.service.spec.ts
+++ b/apps/app-notifications/src/notifications/fcm.service.spec.ts
@@ -210,6 +210,27 @@ describe('FcmService device unregistration', () => {
   });
 });
 
+describe('FcmService device locale updates', () => {
+  it('succeeds when the device subscription does not exist', async () => {
+    const updateMany = jest.fn().mockResolvedValue({ count: 0 });
+    const prisma = {
+      deviceSubscription: { updateMany },
+    } as unknown as PrismaService;
+    const service = new FcmService(prisma, {
+      capture: jest.fn(),
+    } as unknown as PostHogService);
+
+    await expect(
+      service.updateDeviceLocale('missing-token', 'nl-BE'),
+    ).resolves.toBeUndefined();
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { deviceToken: 'missing-token' },
+      data: { locale: 'nl' },
+    });
+  });
+});
+
 describe('FcmService topic lookup', () => {
   it('deduplicates devices subscribed through several matching topics', async () => {
     const findMany = jest.fn().mockResolvedValue([

--- a/apps/app-notifications/src/notifications/fcm.service.ts
+++ b/apps/app-notifications/src/notifications/fcm.service.ts
@@ -122,7 +122,9 @@ export class FcmService implements OnModuleInit {
 
   async updateDeviceLocale(deviceToken: string, locale: string): Promise<void> {
     try {
-      await this.prisma.deviceSubscription.update({
+      // A device can have an FCM token without a backend subscription when
+      // notifications are disabled. Locale updates are therefore idempotent.
+      await this.prisma.deviceSubscription.updateMany({
         where: { deviceToken },
         data: { locale: normalizeNotificationLocale(locale) },
       });


### PR DESCRIPTION
## Impact

PostHog issue `019ff58f-267f-7951-b232-ef37b1772a61` recorded 2 occurrences affecting 2 users in the latest 24-hour window (1 occurrence in the previous window). Locale changes returned a server error when the FCM token had no backend subscription.

## Root cause

The mobile app can have a valid FCM token while notifications are disabled, so no `DeviceSubscription` row exists. `updateDeviceLocale` used Prisma `update()`, which throws when that row is absent.

## Fix

Use `updateMany()` so locale updates remain idempotent for missing subscriptions while preserving locale normalization for existing records.

## Tests

- `pnpm exec jest apps/app-notifications/src/notifications/fcm.service.spec.ts --runInBand --coverage=false` — 7 passed
- `pnpm test --runInBand` — 73 suites / 361 tests passed
- ESLint on changed files — passed
- `pnpm run typecheck:all` — TypeScript 6 and 7 passed
- `pnpm run build:app-notifications` — passed

PostHog reference: https://eu.posthog.com/project/216441/error_tracking/019ff58f-267f-7951-b232-ef37b1772a61
