### PR TITLE
feat(api): add resilient member lookup

### DIFF
--- a/apps/tabt-rest/src/api/member/controllers/member.controller.spec.ts
+++ b/apps/tabt-rest/src/api/member/controllers/member.controller.spec.ts
@@ -6,15 +6,18 @@ import { NotFoundException } from '@nestjs/common';
 import { SeasonService } from '../../../services/seasons/season.service';
 import { NumericRankingService } from '../../../services/members/numeric-ranking.service';
 import { MemberCategoryService } from '../../../services/members/member-category.service';
+import { MemberLookupService } from '../../../services/members/member-lookup.service';
 
 jest.mock('../../../services/members/member.service');
 jest.mock('../../../services/seasons/season.service');
 jest.mock('../../../services/members/member-category.service');
 jest.mock('../../../services/members/numeric-ranking.service');
+jest.mock('../../../services/members/member-lookup.service');
 
 describe('MemberController', () => {
   let controller: MemberController;
   let service: MemberService;
+  let lookupService: MemberLookupService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -22,6 +25,7 @@ describe('MemberController', () => {
       controllers: [MemberController],
       providers: [
         MemberService,
+        MemberLookupService,
         MemberCategoryService,
         SeasonService,
         NumericRankingService,
@@ -30,10 +34,34 @@ describe('MemberController', () => {
 
     controller = module.get<MemberController>(MemberController);
     service = module.get<MemberService>(MemberService);
+    lookupService = module.get<MemberLookupService>(MemberLookupService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should use the resilient member lookup endpoint', async () => {
+    const members = [
+      {
+        Position: 87,
+        UniqueIndex: 142453,
+        RankingIndex: 87,
+        FirstName: 'Florent',
+        LastName: 'Cardoen',
+        Ranking: 'B4',
+        Status: '',
+        Club: 'L360',
+      },
+    ];
+    const spy = jest
+      .spyOn(lookupService, 'lookupByName')
+      .mockResolvedValue(members);
+
+    await expect(
+      controller.lookup({ nameSearch: 'Florent Cardoen' }),
+    ).resolves.toEqual(members);
+    expect(spy).toHaveBeenCalledWith('Florent Cardoen');
   });
 
   it('should return an empty list when the member search has no result', async () => {

--- a/apps/tabt-rest/src/api/member/controllers/member.controller.ts
+++ b/apps/tabt-rest/src/api/member/controllers/member.controller.ts
@@ -20,6 +20,7 @@ import {
   GetMembersV1,
   GetMemberV1,
   GetPlayerCategoriesInputV1,
+  LookupMembersV1,
   MemberEntryDTOV1,
   PlayerCategoryEntriesDTOV1,
   WeeklyNumericPointsInputV1,
@@ -29,6 +30,7 @@ import {
   NumericRankingService,
   WeeklyRankingV1Response,
 } from '../../../services/members/numeric-ranking.service';
+import { MemberLookupService } from '../../../services/members/member-lookup.service';
 
 @ApiTags('Members')
 @Controller({
@@ -38,6 +40,7 @@ import {
 export class MemberController {
   constructor(
     private readonly memberService: MemberService,
+    private readonly memberLookupService: MemberLookupService,
     private readonly memberCategoryService: MemberCategoryService,
     private readonly numericRankingService: NumericRankingService,
   ) {}
@@ -54,6 +57,21 @@ export class MemberController {
   async findAll(@Query() input: GetMembersV1): Promise<MemberEntryDTOV1[]> {
     const members = await this.memberService.getMembersV1(input);
     return members.map(MemberEntryDTOV1.fromTabT);
+  }
+
+  @Get('lookup')
+  @ApiOperation({
+    operationId: 'lookupMembersV1',
+    summary: 'Look up members across TABT and numeric ranking data',
+  })
+  @ApiOkResponse({
+    type: [MemberEntryDTOV1],
+    description:
+      'Members merged from TABT and the complete numeric ranking member list',
+  })
+  @TabtHeadersDecorator()
+  async lookup(@Query() input: LookupMembersV1): Promise<MemberEntryDTOV1[]> {
+    return this.memberLookupService.lookupByName(input.nameSearch);
   }
 
   @Get('categories')

--- a/apps/tabt-rest/src/api/member/dto/member.dto.ts
+++ b/apps/tabt-rest/src/api/member/dto/member.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
-import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 import { Transform } from 'class-transformer';
 import {
   MemberEntry,
@@ -61,6 +68,21 @@ export class GetMembersV1 extends BaseGetMembersV1 {
 }
 
 export class GetMemberV1 extends OmitType(GetMembersV1, ['uniqueIndex']) {}
+
+export class LookupMembersV1 {
+  @ApiProperty({
+    description: 'Name, or part of a name, to look up across member sources',
+    minLength: 3,
+    maxLength: 100,
+  })
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.trim().replace(/\s+/g, ' ') : value,
+  )
+  @IsString()
+  @MinLength(3)
+  @MaxLength(100)
+  nameSearch: string;
+}
 
 export class RankingPointsEntryDTOV1 {
   @ApiProperty()

--- a/apps/tabt-rest/src/api/member/member.module.ts
+++ b/apps/tabt-rest/src/api/member/member.module.ts
@@ -8,6 +8,7 @@ import { CacheModuleOptsFactory } from '@app/common';
 import { ConfigModule } from '@nestjs/config';
 import { CommonModule } from '../../common/common.module';
 import { ServicesModule } from '../../services/services.module';
+import { MemberLookupService } from '../../services/members/member-lookup.service';
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { ServicesModule } from '../../services/services.module';
     }),
   ],
   controllers: [MemberController, MemberRankingController],
-  providers: [MemberService, RankingDistributionService],
+  providers: [MemberService, MemberLookupService, RankingDistributionService],
   exports: [MemberService, RankingDistributionService],
 })
 export class MemberModule {}

--- a/apps/tabt-rest/src/services/members/member-lookup.service.spec.ts
+++ b/apps/tabt-rest/src/services/members/member-lookup.service.spec.ts
@@ -1,0 +1,154 @@
+import { PrismaService } from '@app/common';
+import { MemberEntry } from '../../entity/tabt-soap/TabTAPI_Port';
+import { MemberLookupService } from './member-lookup.service';
+import { MemberService } from './member.service';
+
+describe('MemberLookupService', () => {
+  const memberService = { getMembersV1: jest.fn() };
+  const prismaService = { member: { findMany: jest.fn() } };
+  let service: MemberLookupService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new MemberLookupService(
+      memberService as unknown as MemberService,
+      prismaService as unknown as PrismaService,
+    );
+  });
+
+  it('merges TABT members with the complete numeric ranking member list', async () => {
+    memberService.getMembersV1.mockResolvedValue([
+      {
+        Position: 1,
+        UniqueIndex: 123,
+        RankingIndex: 1,
+        FirstName: 'JOHN',
+        LastName: 'DOE',
+        Ranking: 'C0',
+        Status: 'A',
+        Club: 'TABT',
+      },
+    ] satisfies MemberEntry[]);
+    prismaService.member.findMany.mockResolvedValue([
+      {
+        licence: 456,
+        firstname: 'JANE',
+        lastname: 'DOE',
+        ranking: 'C2',
+        club: 'DB2',
+        category: 'SEN',
+        playerCategory: 'SENIOR_WOMEN',
+        pointsHistory: [],
+      },
+      {
+        licence: 123,
+        firstname: 'JOHN',
+        lastname: 'DOE',
+        ranking: 'C0',
+        club: 'DB1',
+        category: 'SEN',
+        playerCategory: 'SENIOR_MEN',
+        pointsHistory: [
+          {
+            points: 1469.25,
+            ranking: 87,
+            rankingWI: 102,
+            rankingLetterEstimation: 'B4',
+          },
+        ],
+      },
+    ]);
+
+    const result = await service.lookupByName('  John   Doe  ');
+
+    expect(memberService.getMembersV1).toHaveBeenCalledWith({
+      nameSearch: 'John Doe',
+    });
+    expect(prismaService.member.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            {
+              OR: [
+                { firstname: { contains: 'John', mode: 'insensitive' } },
+                { lastname: { contains: 'John', mode: 'insensitive' } },
+              ],
+            },
+            {
+              OR: [
+                { firstname: { contains: 'Doe', mode: 'insensitive' } },
+                { lastname: { contains: 'Doe', mode: 'insensitive' } },
+              ],
+            },
+          ],
+        },
+        take: 50,
+      }),
+    );
+    expect(result).toHaveLength(2);
+    expect(result.find((member) => member.UniqueIndex === 123)).toEqual(
+      expect.objectContaining({
+        Position: 87,
+        RankingIndex: 87,
+        Ranking: 'B4',
+        RankingPointsCount: 1469.25,
+        Club: 'TABT',
+        Status: 'A',
+      }),
+    );
+    expect(result.find((member) => member.UniqueIndex === 456)).toEqual(
+      expect.objectContaining({
+        Ranking: 'C2',
+        Club: 'DB2',
+        Gender: 'F',
+      }),
+    );
+  });
+
+  it('uses numeric ranking data when TABT does not expose the member', async () => {
+    memberService.getMembersV1.mockRejectedValue(new Error('SOAP down'));
+    prismaService.member.findMany.mockResolvedValue([
+      {
+        licence: 456,
+        firstname: 'JANE',
+        lastname: 'DOE',
+        ranking: 'C2',
+        club: 'DB2',
+        category: 'SEN',
+        playerCategory: 'SENIOR_WOMEN',
+        pointsHistory: [],
+      },
+    ]);
+
+    await expect(service.lookupByName('Jane')).resolves.toEqual([
+      expect.objectContaining({ UniqueIndex: 456, FirstName: 'JANE' }),
+    ]);
+  });
+
+  it('uses TABT when the numeric ranking database is unavailable', async () => {
+    memberService.getMembersV1.mockResolvedValue([
+      {
+        Position: 1,
+        UniqueIndex: 123,
+        RankingIndex: 2,
+        FirstName: 'JOHN',
+        LastName: 'DOE',
+        Ranking: 'C0',
+        Status: 'A',
+        Club: 'TABT',
+      },
+    ] satisfies MemberEntry[]);
+    prismaService.member.findMany.mockRejectedValue(new Error('DB down'));
+
+    await expect(service.lookupByName('John')).resolves.toEqual([
+      expect.objectContaining({ UniqueIndex: 123, Club: 'TABT' }),
+    ]);
+  });
+
+  it('fails when neither source can perform the lookup', async () => {
+    memberService.getMembersV1.mockRejectedValue(new Error('SOAP down'));
+    prismaService.member.findMany.mockRejectedValue(new Error('DB down'));
+
+    await expect(service.lookupByName('John')).rejects.toThrow('DB down');
+  });
+});

--- a/apps/tabt-rest/src/services/members/member-lookup.service.ts
+++ b/apps/tabt-rest/src/services/members/member-lookup.service.ts
@@ -1,0 +1,165 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PlayerCategory, PrismaService } from '@app/common';
+import { MemberEntryDTOV1 } from '../../api/member/dto/member.dto';
+import { MemberService } from './member.service';
+
+const LOOKUP_LIMIT = 50;
+
+type DatabaseMember = {
+  licence: number;
+  firstname: string;
+  lastname: string;
+  ranking: string;
+  club: string;
+  category: string;
+  playerCategory: PlayerCategory;
+  pointsHistory: Array<{
+    points: number;
+    ranking: number | null;
+    rankingWI: number | null;
+    rankingLetterEstimation: string | null;
+  }>;
+};
+
+/**
+ * Member search intended for identity selection flows.
+ *
+ * TABT only exposes members activated for the requested season. The numeric
+ * ranking import contains the full AFTT member list, so both sources are read
+ * and merged. Either source may fail independently without making onboarding
+ * unusable.
+ */
+@Injectable()
+export class MemberLookupService {
+  private readonly logger = new Logger(MemberLookupService.name);
+
+  constructor(
+    private readonly memberService: MemberService,
+    private readonly prismaService: PrismaService,
+  ) {}
+
+  async lookupByName(nameSearch: string): Promise<MemberEntryDTOV1[]> {
+    const normalizedName = nameSearch.trim().replace(/\s+/g, ' ');
+    const [tabtResult, databaseResult] = await Promise.allSettled([
+      this.memberService.getMembersV1({ nameSearch: normalizedName }),
+      this.lookupInNumericRankingDatabase(normalizedName),
+    ]);
+
+    if (
+      tabtResult.status === 'rejected' &&
+      databaseResult.status === 'rejected'
+    ) {
+      this.logger.error(
+        `Member lookup failed in TABT (${this.errorMessage(tabtResult.reason)}) and the numeric ranking database (${this.errorMessage(databaseResult.reason)})`,
+      );
+      throw databaseResult.reason;
+    }
+
+    if (tabtResult.status === 'rejected') {
+      this.logger.warn(
+        `TABT member lookup failed; using numeric ranking data: ${this.errorMessage(tabtResult.reason)}`,
+      );
+    }
+    if (databaseResult.status === 'rejected') {
+      this.logger.warn(
+        `Numeric ranking member lookup failed; using TABT data: ${this.errorMessage(databaseResult.reason)}`,
+      );
+    }
+
+    const databaseMembers =
+      databaseResult.status === 'fulfilled' ? databaseResult.value : [];
+    const mergedByLicence = new Map<number, MemberEntryDTOV1>(
+      databaseMembers.map((member) => [member.UniqueIndex, member]),
+    );
+
+    if (tabtResult.status === 'fulfilled') {
+      for (const tabtMember of tabtResult.value) {
+        const tabtDto = MemberEntryDTOV1.fromTabT(tabtMember);
+        const databaseMember = mergedByLicence.get(tabtDto.UniqueIndex);
+
+        // TABT remains authoritative for current-season identity and club data.
+        // Ranking data is enriched from the latest numeric import when present.
+        mergedByLicence.set(tabtDto.UniqueIndex, {
+          ...tabtDto,
+          Position: databaseMember?.Position ?? tabtDto.Position,
+          RankingIndex: databaseMember?.RankingIndex ?? tabtDto.RankingIndex,
+          Ranking: databaseMember?.Ranking || tabtDto.Ranking,
+          RankingPointsCount:
+            databaseMember?.RankingPointsCount ?? tabtDto.RankingPointsCount,
+        });
+      }
+    }
+
+    return [...mergedByLicence.values()]
+      .sort((left, right) =>
+        `${left.LastName} ${left.FirstName}`.localeCompare(
+          `${right.LastName} ${right.FirstName}`,
+          'fr',
+          { sensitivity: 'base' },
+        ),
+      )
+      .slice(0, LOOKUP_LIMIT);
+  }
+
+  private async lookupInNumericRankingDatabase(
+    nameSearch: string,
+  ): Promise<MemberEntryDTOV1[]> {
+    const nameParts = nameSearch.split(' ');
+    const members = await this.prismaService.member.findMany({
+      where: {
+        AND: nameParts.map((namePart) => ({
+          OR: [
+            { firstname: { contains: namePart, mode: 'insensitive' } },
+            { lastname: { contains: namePart, mode: 'insensitive' } },
+          ],
+        })),
+      },
+      select: {
+        licence: true,
+        firstname: true,
+        lastname: true,
+        ranking: true,
+        club: true,
+        category: true,
+        playerCategory: true,
+        pointsHistory: {
+          orderBy: { date: 'desc' },
+          take: 1,
+          select: {
+            points: true,
+            ranking: true,
+            rankingWI: true,
+            rankingLetterEstimation: true,
+          },
+        },
+      },
+      orderBy: [{ lastname: 'asc' }, { firstname: 'asc' }],
+      take: LOOKUP_LIMIT,
+    });
+
+    return (members as DatabaseMember[]).map((member) => {
+      const latestPoints = member.pointsHistory[0];
+      const numericPosition =
+        latestPoints?.ranking ?? latestPoints?.rankingWI ?? 0;
+
+      return {
+        Position: numericPosition,
+        UniqueIndex: member.licence,
+        RankingIndex: numericPosition,
+        FirstName: member.firstname,
+        LastName: member.lastname,
+        Ranking: latestPoints?.rankingLetterEstimation || member.ranking || '',
+        Status: '',
+        Club: member.club,
+        Gender:
+          member.playerCategory === PlayerCategory.SENIOR_WOMEN ? 'F' : 'M',
+        Category: member.category,
+        RankingPointsCount: latestPoints?.points,
+      } satisfies MemberEntryDTOV1;
+    });
+  }
+
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}


### PR DESCRIPTION
## Ce qui change

- ajoute `GET /v1/members/lookup` pour les recherches de profil dans l’onboarding ;
- fusionne les membres actifs de TABT avec la liste complète issue du classement numérique ;
- enrichit les résultats TABT avec la position, la lettre et les points numériques disponibles ;
- conserve une réponse exploitable lorsqu’une seule des deux sources est indisponible.

## Pourquoi

La recherche TABT seule ne retourne pas tous les membres utiles à la sélection de profil. Le client mobile 4.0.14 sait utiliser ce nouvel endpoint tout en gardant un repli vers l’ancienne recherche pendant le déploiement.

## Validation

- Prettier
- ESLint
- TypeScript 6 et 7
- build Nest `tabt-rest`
- 74 suites Jest, 366 tests
