### PR TITLE
fix: make notification type updates idempotent

### DIFF
--- a/apps/app-notifications/src/notifications/fcm.service.spec.ts
+++ b/apps/app-notifications/src/notifications/fcm.service.spec.ts
@@ -231,6 +231,32 @@ describe('FcmService device locale updates', () => {
   });
 });
 
+describe('FcmService device notification type updates', () => {
+  it('succeeds when the device subscription does not exist', async () => {
+    const updateMany = jest.fn().mockResolvedValue({ count: 0 });
+    const prisma = {
+      deviceSubscription: { updateMany },
+    } as unknown as PrismaService;
+    const service = new FcmService(prisma, {
+      capture: jest.fn(),
+    } as unknown as PostHogService);
+
+    await expect(
+      service.updateDeviceNotificationTypes('missing-token', [
+        NotificationType.MATCH,
+      ]),
+    ).resolves.toBeUndefined();
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { deviceToken: 'missing-token' },
+      data: {
+        notificationTypes: [NotificationType.MATCH],
+        lastUsed: expect.any(Date),
+      },
+    });
+  });
+});
+
 describe('FcmService topic lookup', () => {
   it('deduplicates devices subscribed through several matching topics', async () => {
     const findMany = jest.fn().mockResolvedValue([

--- a/apps/app-notifications/src/notifications/fcm.service.ts
+++ b/apps/app-notifications/src/notifications/fcm.service.ts
@@ -160,7 +160,10 @@ export class FcmService implements OnModuleInit {
     notificationTypes: NotificationType[],
   ): Promise<void> {
     try {
-      await this.prisma.deviceSubscription.update({
+      // The client can persist preferences while device registration is still
+      // pending or after the backend row was removed. Treat that race as an
+      // idempotent no-op; a later registration carries the persisted types.
+      await this.prisma.deviceSubscription.updateMany({
         where: { deviceToken },
         data: {
           notificationTypes,


### PR DESCRIPTION
## Impact

PostHog recorded 2 production failures across 2 users and 2 sessions in the last 24 hours when updating notification types for an FCM token whose `DeviceSubscription` row no longer existed.

PostHog reference: https://eu.posthog.com/project/216441/error_tracking/019ff481-f4a0-73a1-ba39-8e9c6d037c4b

## Root cause

`updateDeviceNotificationTypes` used Prisma `update()`, which throws when the target row is absent. The mobile client can legitimately persist preferences while device registration is pending or after the backend row has been removed.

## Fix

Use `updateMany()` so an absent device is an idempotent no-op. A later device registration carries the locally persisted notification types, so this does not lose the user's preference.

## Tests

- Added a regression test for a missing device subscription
- 75 Jest suites / 376 tests passed
- Full ESLint passed
- TypeScript 6 and TypeScript 7 typechecks passed
- `app-notifications` build passed
